### PR TITLE
Add multilingual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ The project also shows some more advanced Ruby features:
 * `FruitFactory` uses metaprogramming (`method_missing`) to dynamically create fruit objects.
 
 ## Running the demonstration
-Execute the following command in the project directory to see the classes in action:
+Execute the following command in the project directory to see the classes in action.
+You can optionally pass a locale (`en` or `es`) to display the output in a different language:
 
 ```bash
-ruby demo.rb
+# English output
+ruby demo.rb en
+
+# Spanish output
+ruby demo.rb es
 ```
 
 

--- a/demo.rb
+++ b/demo.rb
@@ -16,6 +16,9 @@ require_relative 'lib/rainier_cherry'
 require_relative 'lib/fruit_basket'
 require_relative 'lib/fruit_factory'
 
+# Set the locale based on the first command line argument (default :en)
+Localization.locale = (ARGV.shift || 'en').to_sym
+
 # Instantiate some fruits using the FruitFactory which leverages
 # Ruby's metaprogramming to look up the correct class.
 apple = FruitFactory.apple(name: 'Apple', color: 'red', ripe: true, crunch_level: 7)

--- a/lib/apple.rb
+++ b/lib/apple.rb
@@ -14,6 +14,6 @@ class Apple < Fruit
   # This method overrides Fruit#describe to include the crunch level.
   def describe
     super
-    puts "Crunch level: #{crunch_level}."
+    puts Localization.t('apple.crunch_level', crunch_level: crunch_level)
   end
 end

--- a/lib/banana.rb
+++ b/lib/banana.rb
@@ -13,7 +13,7 @@ class Banana < Fruit
   # This method overrides Fruit#describe to mention the curvature.
   def describe
     super
-    puts "Curvature: #{curvature} degrees."
+    puts Localization.t('banana.curvature', curvature: curvature)
   end
 
   private

--- a/lib/bing_cherry.rb
+++ b/lib/bing_cherry.rb
@@ -16,6 +16,8 @@ class BingCherry
 
   # Prints a short description of the cherry.
   def describe
-    puts "This is a #{ripe ? 'ripe' : 'not ripe'} #{name} with a sweetness level of #{sweetness}."
+    ripe_text = Localization.t(ripe ? 'fruit.ripe' : 'fruit.not_ripe')
+    puts Localization.t('bing_cherry.description', name: name, ripe: ripe_text,
+                        sweetness: sweetness)
   end
 end

--- a/lib/cherry.rb
+++ b/lib/cherry.rb
@@ -12,6 +12,6 @@ class Cherry < Fruit
 
   def describe
     super
-    puts "Sweetness: #{sweetness}."
+    puts Localization.t('cherry.sweetness', sweetness: sweetness)
   end
 end

--- a/lib/fruit.rb
+++ b/lib/fruit.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require_relative 'localization'
+
 # This module provides squeezing behavior for fruits that can be juiced.
 module Squeezable
   # Prints a simple message explaining that the fruit is being squeezed.
   def squeeze
-    puts "You squeeze the #{name} and juice comes out!"
+    puts Localization.t('fruit.squeeze', name: name)
   end
 end
 
@@ -28,7 +30,8 @@ class Fruit
   # will override this method to add their own details while still
   # leveraging the basic description provided here.
   def describe
-    puts "This is a #{color} #{name}. It is #{ripeness_description}."
+    puts Localization.t('fruit.description', color: color, name: name,
+                        ripeness: ripeness_description)
   end
 
   private
@@ -36,6 +39,7 @@ class Fruit
   # A helper method that other methods can use. Marking it private keeps it
   # hidden from users of the class, illustrating encapsulation.
   def ripeness_description
-    ripe ? "ripe" : "not ripe yet"
+    key = ripe ? 'fruit.ripe' : 'fruit.not_ripe'
+    Localization.t(key)
   end
 end

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -15,7 +15,8 @@ class Grape < Fruit
   # Override Fruit#describe to mention whether the grape is seedless.
   def describe
     super
-    description = seedless ? 'seedless' : 'with seeds'
-    puts "This grape is #{description}."
+    descriptor_key = seedless ? 'grape.seedless' : 'grape.with_seeds'
+    descriptor = Localization.t(descriptor_key)
+    puts Localization.t('grape.description', descriptor: descriptor)
   end
 end

--- a/lib/grapefruit.rb
+++ b/lib/grapefruit.rb
@@ -13,6 +13,6 @@ class Grapefruit < Fruit
 
   def describe
     super
-    puts "Bitterness: #{bitterness}."
+    puts Localization.t('grapefruit.bitterness', bitterness: bitterness)
   end
 end

--- a/lib/lemon.rb
+++ b/lib/lemon.rb
@@ -13,6 +13,6 @@ class Lemon < Fruit
 
   def describe
     super
-    puts "Tartness: #{tartness}."
+    puts Localization.t('lemon.tartness', tartness: tartness)
   end
 end

--- a/lib/localization.rb
+++ b/lib/localization.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+# Simple localization module to load translations from YAML files.
+module Localization
+  class << self
+    attr_accessor :locale
+
+    # Translate a dotted key using the current locale. Placeholders can be
+    # interpolated using `%{placeholder}` syntax.
+    def t(key, **options)
+      load_translations(locale)
+      value = key.to_s.split('.').reduce(translations[locale]) do |acc, part|
+        acc && acc[part]
+      end
+      value ||= key
+      if value.is_a?(String)
+        options.each { |k, v| value = value.gsub("%{#{k}}", v.to_s) }
+      end
+      value
+    end
+
+    private
+
+    def translations
+      @translations ||= {}
+    end
+
+    def load_translations(loc)
+      return if translations[loc]
+
+      file = File.join(__dir__, '..', 'locales', "#{loc}.yml")
+      translations[loc] = File.exist?(file) ? YAML.load_file(file) : {}
+    end
+  end
+
+  self.locale = :en
+end

--- a/lib/orange.rb
+++ b/lib/orange.rb
@@ -15,6 +15,6 @@ class Orange < Fruit
   # Override Fruit#describe to include segment information.
   def describe
     super
-    puts "Segment count: #{segment_count}."
+    puts Localization.t('orange.segment_count', segment_count: segment_count)
   end
 end

--- a/lib/pear.rb
+++ b/lib/pear.rb
@@ -13,6 +13,6 @@ class Pear < Fruit
   # Override Fruit#describe to include the softness value.
   def describe
     super
-    puts "Softness level: #{softness}."
+    puts Localization.t('pear.softness', softness: softness)
   end
 end

--- a/lib/rainier_cherry.rb
+++ b/lib/rainier_cherry.rb
@@ -4,6 +4,6 @@
 class RainierCherry < Cherry
   def describe
     super
-    puts 'Variety: Rainier.'
+    puts Localization.t('rainier_cherry.variety')
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,37 @@
+fruit:
+  squeeze: "You squeeze the %{name} and juice comes out!"
+  description: "This is a %{color} %{name}. It is %{ripeness}."
+  ripe: "ripe"
+  not_ripe: "not ripe yet"
+
+apple:
+  crunch_level: "Crunch level: %{crunch_level}."
+
+banana:
+  curvature: "Curvature: %{curvature} degrees."
+
+orange:
+  segment_count: "Segment count: %{segment_count}."
+
+pear:
+  softness: "Softness level: %{softness}."
+
+grape:
+  description: "This grape is %{descriptor}."
+  seedless: "seedless"
+  with_seeds: "with seeds"
+
+lemon:
+  tartness: "Tartness: %{tartness}."
+
+grapefruit:
+  bitterness: "Bitterness: %{bitterness}."
+
+cherry:
+  sweetness: "Sweetness: %{sweetness}."
+
+bing_cherry:
+  description: "This is a %{ripe} %{name} with a sweetness level of %{sweetness}."
+
+rainier_cherry:
+  variety: "Variety: Rainier."

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -1,0 +1,37 @@
+fruit:
+  squeeze: "Exprimes la %{name} y sale jugo!"
+  description: "Esta es una %{name} %{color}. Está %{ripeness}."
+  ripe: "madura"
+  not_ripe: "no está madura todavía"
+
+apple:
+  crunch_level: "Nivel de crujido: %{crunch_level}."
+
+banana:
+  curvature: "Curvatura: %{curvature} grados."
+
+orange:
+  segment_count: "Número de gajos: %{segment_count}."
+
+pear:
+  softness: "Nivel de suavidad: %{softness}."
+
+grape:
+  description: "Esta uva es %{descriptor}."
+  seedless: "sin semillas"
+  with_seeds: "con semillas"
+
+lemon:
+  tartness: "Acidez: %{tartness}."
+
+grapefruit:
+  bitterness: "Amargor: %{bitterness}."
+
+cherry:
+  sweetness: "Dulzura: %{sweetness}."
+
+bing_cherry:
+  description: "Esta es una %{name} %{ripe} con un nivel de dulzura de %{sweetness}."
+
+rainier_cherry:
+  variety: "Variedad: Rainier."

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,1 +1,5 @@
 require 'minitest/autorun'
+require_relative '../lib/localization'
+
+# Ensure tests run with the English locale
+Localization.locale = :en


### PR DESCRIPTION
## Summary
- implement a basic Localization module with YAML translations
- add English and Spanish locale files
- update fruit classes to use translation helpers
- update demo to accept a locale argument
- ensure tests load Localization and set locale to English
- document how to run the demo in different languages

## Testing
- `rake`
- `ruby demo.rb es | head -n 20`
